### PR TITLE
Make 'craft_guide' dependency optional

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,2 +1,2 @@
 default
-craft_guide
+craft_guide?


### PR DESCRIPTION
*craft_guide* is not necessary for the mod to work correctly.